### PR TITLE
docs: add frontmatter description for llms.txt hierarchy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Bot Standard
+description: Standard bot defense with signature-based detection for F5 Distributed Cloud.
 hero:
   tagline: Standard bot defense with signature-based detection.
   image:


### PR DESCRIPTION
## Summary

- Adds a `description:` field to `docs/index.mdx` frontmatter for the starlight-llms-txt plugin

Refs f5xc-salesdemos/xcsh#223

Step 5c of the cascading llms.txt knowledge hierarchy — adds a `description:` field to the index page frontmatter so the starlight-llms-txt plugin can include it in the llms.txt output.

Closes #225

## Test plan

- [ ] CI checks pass
- [ ] Verify the `description:` field is valid YAML frontmatter
- [ ] Confirm starlight-llms-txt plugin picks up the description in llms.txt output