### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -9,6 +9,12 @@ on:
     paths:
       - '.github/config/**'
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: 'Commit SHA of the docs-control push that triggered this run. Forwarded to sync-managed-files for Pages staleness check.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -20,10 +26,14 @@ concurrency:
 jobs:
   enforce-settings:
     uses: f5xc-salesdemos/docs-control/.github/workflows/enforce-repo-settings.yml@main
+    with:
+      source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
 
   sync-files:
     uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main
+    with:
+      source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-sync-token: ${{ secrets.REPO_SYNC_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,13 @@ Never run `git commit`, `git push`, `gh pr create` directly.
 ```
 Agent(
   subagent_type="f5xc-github-ops:github-ops",
+  mode="bypassPermissions",
   prompt="<type>: <desc>\n\nFiles:\n- <list>\n\nWhy: <reason>"
 )
 ```
+
+`mode="bypassPermissions"` is required — without it, plan mode can
+re-engage mid-workflow and strip the agent's Bash access, leaving
+it stuck after the first step.
 
 See `CONTRIBUTING.md` for project rules.


### PR DESCRIPTION
Closes #237

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/enforce-repo-settings.yml
- README.md
- CLAUDE.md
- .gitignore
- .pre-commit-config.yaml
- .yamllint.yaml
- .markdownlint.json
- .github/workflows/dependabot-auto-merge.yml
- biome.json
- .jscpd.json
- .textlintrc
- .checkov.yaml
- zizmor.yaml
- .codespellrc
- .prettierignore
- trivy.yaml
- .ruff.toml
- ruff.toml
- .isort.cfg
- .python-lint
- .mypy.ini
- .claude/governance.json
- .claude/settings.json
- .claude/hooks/protect-managed-files.sh
- .claude/hooks/enforce-git-delegation.sh