### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -5,16 +5,15 @@
       "biome.json",
       "LICENSE",
       "CONTRIBUTING.md",
-      "ruff.toml",
       ".ruff.toml",
       ".python-lint",
       ".mypy.ini",
       ".github/workflows/super-linter.yml"
     ],
-    "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
-    "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
-    "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
-    "i18n-core": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
+    "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
+    "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini"],
+    "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
   },
   "protected_files": [
     ".github/workflows/github-pages-deploy.yml",
@@ -48,7 +47,6 @@
     ".gitleaks.toml",
     ".prettierignore",
     ".trivyignore",
-    "ruff.toml",
     ".ruff.toml",
     ".isort.cfg",
     ".python-lint",

--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ packages/ai/test/.temp-images/
 docs/superpowers/
 !.xcsh/
 .xcsh/plugins/
+.xcsh/contexts/
 .pi_config/
 .opencode/
 .worktree-test-baseline.txt

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -2,6 +2,9 @@
   "threshold": 10,
   "reporters": ["console"],
   "ignore": [
+    "**/*.yaml",
+    "**/*.yml",
+    "**/snapshots/**",
     "**/.github/workflows/**",
     "**/workflows/**",
     "**/node_modules/**",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,5 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - The `main` branch is protected — never commit or push directly to it.
 - Create a feature branch, commit there, and open a pull request.
 - Every pull request must reference a GitHub issue (CI enforces this).
-- **Perform all git operations directly.** Do not delegate git commits,
-  pushes, or pull requests to subagents. Run `git`, `gh`, and CLI
-  commands yourself.
 
 See `CONTRIBUTING.md` for project rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,7 @@ If you are Claude Code, Copilot, or another AI coding assistant, follow these ru
 2. **Always work on a feature branch.** Never commit directly to `main`.
 3. **Always link the PR to the issue.** Use `Closes #N` in the PR description.
 4. **Use the `/ship` skill** when available — it handles the full Issue → Branch → PR flow.
-5. **Perform git operations directly.** Run `git commit`, `git push`, and `gh pr create` yourself. Do not delegate to subagents.
-6. **Never force push** or attempt to bypass branch protection.
-7. **Fill out the PR template checklist** completely.
-8. **Follow the branch naming convention**: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`.
-9. **Respect CODEOWNERS** — Review the CODEOWNERS file for the default reviewer.
+5. **Never force push** or attempt to bypass branch protection.
+6. **Fill out the PR template checklist** completely.
+7. **Follow the branch naming convention**: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`.
+8. **Respect CODEOWNERS** — Review the CODEOWNERS file for the default reviewer.


### PR DESCRIPTION
Closes #476

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- CONTRIBUTING.md
- CLAUDE.md
- .gitignore
- .jscpd.json
- .claude/governance.json