### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -7,7 +7,8 @@
   },
   "defaults": {
     "replicas": 1,
-    "profile": "ubuntu-24.04"
+    "profile": "ubuntu-24.04",
+    "standby_profiles": ["ubuntu-24.04"]
   },
   "profiles": {
     "ubuntu-24.04": {


### PR DESCRIPTION
Closes #779

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/config/self-hosted-runner-policy.json